### PR TITLE
fix: km 39 arrumar a promoção do setor 10

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -78,6 +78,8 @@
             this.pnlTabuleiro = new System.Windows.Forms.Panel();
             this.lblVotosRestantes = new System.Windows.Forms.Label();
             this.tmrVerificarVez = new System.Windows.Forms.Timer(this.components);
+            this.lblRodadaAtual = new System.Windows.Forms.Label();
+            this.lblStatusPartida = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // lblInfoGame
@@ -480,7 +482,7 @@
             // lblVezNomeJogador
             // 
             this.lblVezNomeJogador.AutoSize = true;
-            this.lblVezNomeJogador.Location = new System.Drawing.Point(539, 103);
+            this.lblVezNomeJogador.Location = new System.Drawing.Point(539, 108);
             this.lblVezNomeJogador.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblVezNomeJogador.Name = "lblVezNomeJogador";
             this.lblVezNomeJogador.Size = new System.Drawing.Size(98, 16);
@@ -490,7 +492,7 @@
             // lblVezIdJogador
             // 
             this.lblVezIdJogador.AutoSize = true;
-            this.lblVezIdJogador.Location = new System.Drawing.Point(539, 137);
+            this.lblVezIdJogador.Location = new System.Drawing.Point(539, 138);
             this.lblVezIdJogador.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblVezIdJogador.Name = "lblVezIdJogador";
             this.lblVezIdJogador.Size = new System.Drawing.Size(72, 16);
@@ -581,6 +583,25 @@
             this.tmrVerificarVez.Interval = 5000;
             this.tmrVerificarVez.Tick += new System.EventHandler(this.tmrVerificarVez_Tick);
             // 
+            // lblRodadaAtual
+            // 
+            this.lblRodadaAtual.AutoSize = true;
+            this.lblRodadaAtual.Location = new System.Drawing.Point(539, 43);
+            this.lblRodadaAtual.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.lblRodadaAtual.Name = "lblRodadaAtual";
+            this.lblRodadaAtual.Size = new System.Drawing.Size(92, 16);
+            this.lblRodadaAtual.TabIndex = 55;
+            this.lblRodadaAtual.Text = "Rodada atual:";
+            // 
+            // lblStatusPartida
+            // 
+            this.lblStatusPartida.AutoSize = true;
+            this.lblStatusPartida.Location = new System.Drawing.Point(539, 23);
+            this.lblStatusPartida.Name = "lblStatusPartida";
+            this.lblStatusPartida.Size = new System.Drawing.Size(95, 16);
+            this.lblStatusPartida.TabIndex = 56;
+            this.lblStatusPartida.Text = "Status partida: ";
+            // 
             // KingMe
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -588,6 +609,8 @@
             this.AutoSize = true;
             this.AutoValidate = System.Windows.Forms.AutoValidate.EnableAllowFocusChange;
             this.ClientSize = new System.Drawing.Size(1640, 896);
+            this.Controls.Add(this.lblStatusPartida);
+            this.Controls.Add(this.lblRodadaAtual);
             this.Controls.Add(this.pnlTabuleiro);
             this.Controls.Add(this.txtVoto);
             this.Controls.Add(this.btnVotar);
@@ -699,5 +722,7 @@
         private System.Windows.Forms.Panel pnlTabuleiro;
         private System.Windows.Forms.Label lblVotosRestantes;
         private System.Windows.Forms.Timer tmrVerificarVez;
+        private System.Windows.Forms.Label lblRodadaAtual;
+        private System.Windows.Forms.Label lblStatusPartida;
     }
 }

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -80,7 +80,6 @@
             this.tmrVerificarVez = new System.Windows.Forms.Timer(this.components);
             this.lblRodadaAtual = new System.Windows.Forms.Label();
             this.lblStatusPartida = new System.Windows.Forms.Label();
-            this.txtTabuleiro = new System.Windows.Forms.TextBox();
             this.SuspendLayout();
             // 
             // lblInfoGame
@@ -603,14 +602,6 @@
             this.lblStatusPartida.TabIndex = 56;
             this.lblStatusPartida.Text = "Status partida: ";
             // 
-            // txtTabuleiro
-            // 
-            this.txtTabuleiro.Location = new System.Drawing.Point(972, 477);
-            this.txtTabuleiro.Multiline = true;
-            this.txtTabuleiro.Name = "txtTabuleiro";
-            this.txtTabuleiro.Size = new System.Drawing.Size(122, 173);
-            this.txtTabuleiro.TabIndex = 57;
-            // 
             // KingMe
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -618,7 +609,6 @@
             this.AutoSize = true;
             this.AutoValidate = System.Windows.Forms.AutoValidate.EnableAllowFocusChange;
             this.ClientSize = new System.Drawing.Size(1640, 896);
-            this.Controls.Add(this.txtTabuleiro);
             this.Controls.Add(this.lblStatusPartida);
             this.Controls.Add(this.lblRodadaAtual);
             this.Controls.Add(this.pnlTabuleiro);
@@ -734,6 +724,5 @@
         private System.Windows.Forms.Timer tmrVerificarVez;
         private System.Windows.Forms.Label lblRodadaAtual;
         private System.Windows.Forms.Label lblStatusPartida;
-        private System.Windows.Forms.TextBox txtTabuleiro;
     }
 }

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -70,8 +70,6 @@
             this.lblVezNomeJogador = new System.Windows.Forms.Label();
             this.lblVezIdJogador = new System.Windows.Forms.Label();
             this.txtPersonagensFavoritos = new System.Windows.Forms.TextBox();
-            this.lblTabuleiroAtual = new System.Windows.Forms.Label();
-            this.txtTabuleiroAtual = new System.Windows.Forms.TextBox();
             this.btnMoverPersonagem = new System.Windows.Forms.Button();
             this.label2 = new System.Windows.Forms.Label();
             this.btnPromover = new System.Windows.Forms.Button();
@@ -353,7 +351,7 @@
             // 
             this.lblPersonagensFav.AutoSize = true;
             this.lblPersonagensFav.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.lblPersonagensFav.Location = new System.Drawing.Point(355, 602);
+            this.lblPersonagensFav.Location = new System.Drawing.Point(405, 271);
             this.lblPersonagensFav.Name = "lblPersonagensFav";
             this.lblPersonagensFav.Size = new System.Drawing.Size(72, 16);
             this.lblPersonagensFav.TabIndex = 30;
@@ -380,7 +378,7 @@
             // 
             // btnExibirCartas
             // 
-            this.btnExibirCartas.Location = new System.Drawing.Point(332, 622);
+            this.btnExibirCartas.Location = new System.Drawing.Point(379, 452);
             this.btnExibirCartas.Margin = new System.Windows.Forms.Padding(4);
             this.btnExibirCartas.Name = "btnExibirCartas";
             this.btnExibirCartas.Size = new System.Drawing.Size(123, 28);
@@ -392,19 +390,18 @@
             // lblPersonagensExistentes
             // 
             this.lblPersonagensExistentes.AutoSize = true;
-            this.lblPersonagensExistentes.Location = new System.Drawing.Point(984, 514);
+            this.lblPersonagensExistentes.Location = new System.Drawing.Point(991, 275);
             this.lblPersonagensExistentes.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblPersonagensExistentes.Name = "lblPersonagensExistentes";
             this.lblPersonagensExistentes.Size = new System.Drawing.Size(88, 16);
             this.lblPersonagensExistentes.TabIndex = 34;
             this.lblPersonagensExistentes.Text = "Personagens";
-            this.lblPersonagensExistentes.Click += new System.EventHandler(this.label2_Click);
             // 
             // txtPersonagensExistentes
             // 
             this.txtPersonagensExistentes.FormattingEnabled = true;
             this.txtPersonagensExistentes.ItemHeight = 16;
-            this.txtPersonagensExistentes.Location = new System.Drawing.Point(963, 535);
+            this.txtPersonagensExistentes.Location = new System.Drawing.Point(972, 295);
             this.txtPersonagensExistentes.Margin = new System.Windows.Forms.Padding(4);
             this.txtPersonagensExistentes.Name = "txtPersonagensExistentes";
             this.txtPersonagensExistentes.Size = new System.Drawing.Size(129, 148);
@@ -435,7 +432,7 @@
             // lblSetoresExistentes
             // 
             this.lblSetoresExistentes.AutoSize = true;
-            this.lblSetoresExistentes.Location = new System.Drawing.Point(1003, 11);
+            this.lblSetoresExistentes.Location = new System.Drawing.Point(1011, 23);
             this.lblSetoresExistentes.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblSetoresExistentes.Name = "lblSetoresExistentes";
             this.lblSetoresExistentes.Size = new System.Drawing.Size(54, 16);
@@ -489,7 +486,6 @@
             this.lblVezNomeJogador.Size = new System.Drawing.Size(98, 16);
             this.lblVezNomeJogador.TabIndex = 43;
             this.lblVezNomeJogador.Text = "Nome Jogador";
-            this.lblVezNomeJogador.Click += new System.EventHandler(this.lblVezNomeJogador_Click);
             // 
             // lblVezIdJogador
             // 
@@ -500,34 +496,15 @@
             this.lblVezIdJogador.Size = new System.Drawing.Size(72, 16);
             this.lblVezIdJogador.TabIndex = 44;
             this.lblVezIdJogador.Text = "Id Jogador";
-            this.lblVezIdJogador.Click += new System.EventHandler(this.lblVezIdJogador_Click);
             // 
             // txtPersonagensFavoritos
             // 
-            this.txtPersonagensFavoritos.Location = new System.Drawing.Point(461, 496);
+            this.txtPersonagensFavoritos.Location = new System.Drawing.Point(368, 289);
             this.txtPersonagensFavoritos.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.txtPersonagensFavoritos.Multiline = true;
             this.txtPersonagensFavoritos.Name = "txtPersonagensFavoritos";
             this.txtPersonagensFavoritos.Size = new System.Drawing.Size(148, 157);
             this.txtPersonagensFavoritos.TabIndex = 45;
-            // 
-            // lblTabuleiroAtual
-            // 
-            this.lblTabuleiroAtual.AutoSize = true;
-            this.lblTabuleiroAtual.Location = new System.Drawing.Point(984, 263);
-            this.lblTabuleiroAtual.Name = "lblTabuleiroAtual";
-            this.lblTabuleiroAtual.Size = new System.Drawing.Size(98, 16);
-            this.lblTabuleiroAtual.TabIndex = 46;
-            this.lblTabuleiroAtual.Text = "Tabuleiro Atual";
-            // 
-            // txtTabuleiroAtual
-            // 
-            this.txtTabuleiroAtual.Location = new System.Drawing.Point(943, 282);
-            this.txtTabuleiroAtual.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.txtTabuleiroAtual.Multiline = true;
-            this.txtTabuleiroAtual.Name = "txtTabuleiroAtual";
-            this.txtTabuleiroAtual.Size = new System.Drawing.Size(173, 214);
-            this.txtTabuleiroAtual.TabIndex = 47;
             // 
             // btnMoverPersonagem
             // 
@@ -617,8 +594,6 @@
             this.Controls.Add(this.btnPromover);
             this.Controls.Add(this.label2);
             this.Controls.Add(this.btnMoverPersonagem);
-            this.Controls.Add(this.txtTabuleiroAtual);
-            this.Controls.Add(this.lblTabuleiroAtual);
             this.Controls.Add(this.txtPersonagensFavoritos);
             this.Controls.Add(this.lblVezIdJogador);
             this.Controls.Add(this.lblVezNomeJogador);
@@ -716,8 +691,6 @@
         private System.Windows.Forms.Label lblVezNomeJogador;
         private System.Windows.Forms.Label lblVezIdJogador;
         private System.Windows.Forms.TextBox txtPersonagensFavoritos;
-        private System.Windows.Forms.Label lblTabuleiroAtual;
-        private System.Windows.Forms.TextBox txtTabuleiroAtual;
         private System.Windows.Forms.Button btnMoverPersonagem;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Button btnPromover;

--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -80,6 +80,7 @@
             this.tmrVerificarVez = new System.Windows.Forms.Timer(this.components);
             this.lblRodadaAtual = new System.Windows.Forms.Label();
             this.lblStatusPartida = new System.Windows.Forms.Label();
+            this.txtTabuleiro = new System.Windows.Forms.TextBox();
             this.SuspendLayout();
             // 
             // lblInfoGame
@@ -602,6 +603,14 @@
             this.lblStatusPartida.TabIndex = 56;
             this.lblStatusPartida.Text = "Status partida: ";
             // 
+            // txtTabuleiro
+            // 
+            this.txtTabuleiro.Location = new System.Drawing.Point(972, 477);
+            this.txtTabuleiro.Multiline = true;
+            this.txtTabuleiro.Name = "txtTabuleiro";
+            this.txtTabuleiro.Size = new System.Drawing.Size(122, 173);
+            this.txtTabuleiro.TabIndex = 57;
+            // 
             // KingMe
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
@@ -609,6 +618,7 @@
             this.AutoSize = true;
             this.AutoValidate = System.Windows.Forms.AutoValidate.EnableAllowFocusChange;
             this.ClientSize = new System.Drawing.Size(1640, 896);
+            this.Controls.Add(this.txtTabuleiro);
             this.Controls.Add(this.lblStatusPartida);
             this.Controls.Add(this.lblRodadaAtual);
             this.Controls.Add(this.pnlTabuleiro);
@@ -724,5 +734,6 @@
         private System.Windows.Forms.Timer tmrVerificarVez;
         private System.Windows.Forms.Label lblRodadaAtual;
         private System.Windows.Forms.Label lblStatusPartida;
+        private System.Windows.Forms.TextBox txtTabuleiro;
     }
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -395,13 +395,21 @@ namespace king_me
         {
             tmrVerificarVez.Enabled = false;
 
+           
             //verificação se a rodada foi alterada
             string retornoDLL = KingMeServer.Jogo.VerificarVez(int.Parse(txtIdPartida.Text));
             string[] partes = retornoDLL.Split(',');
             statusPartida = partes[1].Trim();
             lblStatusPartida.Text = "Status partida: " + statusPartida;
-            int rodada = int.Parse(partes[2].Trim());
+            
+            if(statusPartida == "E")
+            {
+                MessageBox.Show("Partida Encerrada.");
+                tmrVerificarVez.Stop();
+                return;
+            }
 
+            int rodada = int.Parse(partes[2].Trim());
             string[] linhasTabuleiro = retornoDLL.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
             retornoDLL = string.Join("\r\n", linhasTabuleiro.Skip(1));
             txtTabuleiro.Text = retornoDLL;
@@ -455,7 +463,7 @@ namespace king_me
                     string[] partes = linha.Split(',');
                     if (partes.Length >= 2 && int.TryParse(partes[0], out int setor))
                     {
-                        if (setor >= 1 && setor <= 5 && !_tabuleiroService.IsSetorCheio(setor + 1, int.Parse(txtIdPartida.Text)))
+                        if (setor >= 0 && setor <= 5 && !_tabuleiroService.IsSetorCheio(setor + 1, int.Parse(txtIdPartida.Text)))
                         {
                             personagensPromoviveis.Add(partes[1]);
                         }

--- a/Form1.cs
+++ b/Form1.cs
@@ -285,7 +285,9 @@ namespace king_me
                 }
 
                 // Se personagem chegou no setor 10, e for a vez do jogador logado, vota automaticamente
-                string tabuleiro = txtTabuleiroAtual.Text;
+                string tabuleiro = KingMeServer.Jogo.VerificarVez(int.Parse(txtIdPartida.Text));
+                string[] linhasTabuleiro = tabuleiro.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                tabuleiro = string.Join("\r\n", linhasTabuleiro.Skip(1));
                 if (tabuleiro.Contains("10"))
                 {
                     if (txtIdJogador.Text == jogadorDaVez.IdJogador)
@@ -424,7 +426,10 @@ namespace king_me
                 int idJogador = int.Parse(txtIdJogador.Text);
                 string senhaJogador = txtSenhaJogador.Text;
 
-                string tabuleiro = txtTabuleiroAtual.Text;
+                string tabuleiro = KingMeServer.Jogo.VerificarVez(int.Parse(txtIdPartida.Text));
+                string[] linhasTabuleiro = tabuleiro.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                tabuleiro = string.Join("\r\n", linhasTabuleiro.Skip(1));
+
                 if (string.IsNullOrEmpty(tabuleiro))
                     return;
 
@@ -436,7 +441,6 @@ namespace king_me
                     string[] partes = linha.Split(',');
                     if (partes.Length >= 2 && int.TryParse(partes[0], out int setor))
                     {
-                        // setor para ser promocionavel deve ser entre 1 e 4 e o setor acima dele não deve estar cheio
                         if (setor >= 1 && setor <= 5 && !_tabuleiroService.IsSetorCheio(setor + 1, int.Parse(txtIdPartida.Text)))
                         {
                             personagensPromoviveis.Add(partes[1]);
@@ -454,6 +458,10 @@ namespace king_me
                     {
                         _tabuleiroService.AtualizarTabuleiro(pnlTabuleiro, retorno);
                         txtTabuleiroAtual.Text = retorno;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException("Não foi possível promover o personagem automaticamente.");
                     }
                 }
             }

--- a/Form1.cs
+++ b/Form1.cs
@@ -412,7 +412,6 @@ namespace king_me
             int rodada = int.Parse(partes[2].Trim());
             string[] linhasTabuleiro = retornoDLL.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
             retornoDLL = string.Join("\r\n", linhasTabuleiro.Skip(1));
-            txtTabuleiro.Text = retornoDLL;
 
             if (rodada != rodadaAtual)
             {

--- a/Form1.cs
+++ b/Form1.cs
@@ -23,7 +23,8 @@ namespace king_me
         private bool SucessoIniciarPartida = false;
         private Mao mao = new Mao();
         private readonly IVotoService _votoService;
-
+        int rodadaAtual = 1;
+        string statusPartida;
         public KingMe(IPartidaService partidaService, IJogadorService jogadorService, ICartaService cartaService, IVotoService votoService, ITabuleiroService tabuleiroService)
 
         {
@@ -120,7 +121,7 @@ namespace king_me
             txtPersonagem.Visible = false;
             lblSetor.Visible = false;
             lblPersonagem.Visible = false;
-
+            lblRodadaAtual.Text = "Rodada atual: " + rodadaAtual;
             // Ativa o timer automático
             tmrVerificarVez.Start();
 
@@ -398,6 +399,20 @@ namespace king_me
         private void tmrVerificarVez_Tick(object sender, EventArgs e)
         {
             tmrVerificarVez.Enabled = false;
+
+            //verificação se a rodada foi alterada
+            string retornoDLL = KingMeServer.Jogo.VerificarVez(int.Parse(txtIdPartida.Text));
+            string[] partes = retornoDLL.Split(',');
+            statusPartida = partes[1].Trim();
+            lblStatusPartida.Text = "Status partida: " + statusPartida;
+            int rodada = int.Parse(partes[2].Trim());
+            
+            if (rodada != rodadaAtual)
+            {
+                lblRodadaAtual.Text = "Rodada atual: " + rodada;
+                _votoService.ResetarVotosJogadores(int.Parse(txtIdPartida.Text));
+            }
+
             bool minhaVez = VerificarVez();
             VerificarTabuleiro();
             
@@ -592,6 +607,5 @@ namespace king_me
             lblVotosRestantes.Text = $"Votos restantes: {votosRestantes}";
 
         }
-
     }
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -383,7 +383,6 @@ namespace king_me
             }
 
             _tabuleiroService.AtualizarTabuleiro(pnlTabuleiro, retornoDLL);
-            txtTabuleiroAtual.Text = retornoDLL;
 
             txtPersonagem.Clear();
             txtPersonagem.Focus();
@@ -457,7 +456,6 @@ namespace king_me
                     if (!retorno.StartsWith("ERRO"))
                     {
                         _tabuleiroService.AtualizarTabuleiro(pnlTabuleiro, retorno);
-                        txtTabuleiroAtual.Text = retorno;
                     }
                     else
                     {
@@ -496,14 +494,10 @@ namespace king_me
 
             // Atualiza o tabuleiro visual
             _tabuleiroService.AtualizarTabuleiro(pnlTabuleiro, retorno);
-            txtTabuleiroAtual.Text = retorno;
 
             txtPersonagem.Clear();
             txtPersonagem.Focus();
         }
-
-
-        private void label2_Click(object sender, EventArgs e) { }
 
         private void txtPersonagens_TextChanged(object sender, EventArgs e) { }
 
@@ -539,7 +533,7 @@ namespace king_me
             }
 
             _tabuleiroService.AtualizarTabuleiro(pnlTabuleiro, retorno);
-            txtTabuleiroAtual.Text = retorno;
+
             txtPersonagem.Clear();
             txtPersonagem.Focus();
         }
@@ -596,17 +590,6 @@ namespace king_me
         {
             int votosRestantes = _votoService.GetVotosRestantes(idJogador);
             lblVotosRestantes.Text = $"Votos restantes: {votosRestantes}";
-
-        }
-
-
-        private void lblVezIdJogador_Click(object sender, EventArgs e)
-        {
-
-        }
-
-        private void lblVezNomeJogador_Click(object sender, EventArgs e)
-        {
 
         }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -296,30 +296,25 @@ namespace king_me
                         int idJogador = int.Parse(txtIdJogador.Text);
                         string senhaJogador = txtSenhaJogador.Text;
 
-                        if (_votoService.GetVotosRestantes(idJogador) > 0)
+                        string votoAuto = new Random().Next(2) == 0 ? "S" : "N";
+                        string retorno = _votoService.Votar(idJogador, senhaJogador, votoAuto);
+
+                        if (!retorno.StartsWith("ERRO"))
                         {
-                            string votoAuto = new Random().Next(2) == 0 ? "S" : "N";
-                            string retorno = _votoService.Votar(idJogador, senhaJogador, votoAuto);
+                            txtVoto.Text = votoAuto;
+                            MessageBox.Show($"Voto automático enviado: {votoAuto}", "Votação automática", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                            AtualizarVotosRestantes(idJogador);
 
-                            if (!retorno.StartsWith("ERRO"))
-                            {
-                                txtVoto.Text = votoAuto;
-                                MessageBox.Show($"Voto automático enviado: {votoAuto}", "Votação automática", MessageBoxButtons.OK, MessageBoxIcon.Information);
-
-
-                                AtualizarVotosRestantes(idJogador);
-
-                                lblVotosRestantes.Text = string.Empty;
-                            }
-                            else
-                            {
-                                MessageBox.Show(retorno, "Erro ao votar", MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                            }
+                            lblVotosRestantes.Text = string.Empty;
+                        }
+                        else
+                        {
+                            MessageBox.Show("Erro ao enviar voto automático: " + retorno, "Erro", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
                     }
                     else
                     {
-                        MessageBox.Show("É a vez de outro jogador.", "Aguardando troca de jogador", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        //MessageBox.Show("É a vez de outro jogador.", "Aguardando troca de jogador", MessageBoxButtons.OK, MessageBoxIcon.Information); //comentar essa linha ao depurar com breakpoint
                     }
 
                 }
@@ -406,10 +401,15 @@ namespace king_me
             statusPartida = partes[1].Trim();
             lblStatusPartida.Text = "Status partida: " + statusPartida;
             int rodada = int.Parse(partes[2].Trim());
-            
+
+            string[] linhasTabuleiro = retornoDLL.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+            retornoDLL = string.Join("\r\n", linhasTabuleiro.Skip(1));
+            txtTabuleiro.Text = retornoDLL;
+
             if (rodada != rodadaAtual)
             {
                 lblRodadaAtual.Text = "Rodada atual: " + rodada;
+                rodadaAtual = rodada;
                 _votoService.ResetarVotosJogadores(int.Parse(txtIdPartida.Text));
             }
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -316,7 +316,7 @@ namespace king_me
                     }
                     else
                     {
-                        MessageBox.Show("É a vez de outro jogador. Troque o ID e a senha para votar.", "Aguardando troca de jogador", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        MessageBox.Show("É a vez de outro jogador.", "Aguardando troca de jogador", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }
 
                 }
@@ -429,7 +429,7 @@ namespace king_me
                     return;
 
                 string[] linhas = tabuleiro.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-                List<string> personagensPromociveis = new List<string>();
+                List<string> personagensPromoviveis = new List<string>();
 
                 foreach (string linha in linhas)
                 {
@@ -437,16 +437,16 @@ namespace king_me
                     if (partes.Length >= 2 && int.TryParse(partes[0], out int setor))
                     {
                         // setor para ser promocionavel deve ser entre 1 e 4 e o setor acima dele não deve estar cheio
-                        if (setor >= 1 && setor <= 4 && !_tabuleiroService.IsSetorCheio(setor + 1, int.Parse(txtIdPartida.Text)))
+                        if (setor >= 1 && setor <= 5 && !_tabuleiroService.IsSetorCheio(setor + 1, int.Parse(txtIdPartida.Text)))
                         {
-                            personagensPromociveis.Add(partes[1]);
+                            personagensPromoviveis.Add(partes[1]);
                         }
                     }
                 }
 
-                if (personagensPromociveis.Count > 0)
+                if (personagensPromoviveis.Count > 0)
                 {
-                    string personagemParaPromover = personagensPromociveis[0];
+                    string personagemParaPromover = personagensPromoviveis[0];
 
                     string retorno = _cartaService.Promover(idJogador, senhaJogador, personagemParaPromover);
 

--- a/Form1.resx
+++ b/Form1.resx
@@ -121,6 +121,6 @@
     <value>17, 17</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>25</value>
+    <value>84</value>
   </metadata>
 </root>

--- a/Form1.resx
+++ b/Form1.resx
@@ -120,4 +120,7 @@
   <metadata name="tmrVerificarVez.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
 </root>

--- a/Interfaces/ITabuleiroService.cs
+++ b/Interfaces/ITabuleiroService.cs
@@ -16,7 +16,6 @@ namespace king_me.Interfaces
         void AtualizarTabuleiro(Panel pnl, string statusTabuleiro);
         void RemoverPersonagem(Panel pnl, string personagem);
         void LimparSetor10(Panel pnl);
-        int ObterSetorNãoCheio();
         List<int> ObterSetoresNaoCheios(int idPartida);
         bool IsSetorCheio(int setor, int idPartida);
     }

--- a/Interfaces/IVotoService.cs
+++ b/Interfaces/IVotoService.cs
@@ -5,5 +5,7 @@ namespace king_me.Interfaces
     {
         string Votar(int idJogador, string senha, string voto);
         int GetVotosRestantes(int idJogador);
+
+        void ResetarVotosJogadores(int idPartida);
     }
 }

--- a/Services/TabuleiroService.cs
+++ b/Services/TabuleiroService.cs
@@ -139,19 +139,7 @@ namespace king_me.Services
             }
         }
 
-        public int ObterSetorNãoCheio()
-        {
-            foreach (var setor in setores.OrderByDescending(s => s.NumSetor))
-            {
-                if ((setor.NumSetor > 0 && setor.NumSetor < 5) && setor.QtdPersonagensAtual < 4)
-                {
-                    return setor.NumSetor;
-                }
-            }
-            return -1; //retorna -1 caso não tenha nenhum setor disponível
-        }
-
-        public List<int> ObterSetoresNaoCheios(int idPartida)
+        public List<int> ObterSetoresNaoCheios(int idPartida) //método pra fase de setup
         {
             List<int> setoresDisponiveis = new List<int>();
             for (int i = 1; i <= 4; i++)
@@ -164,10 +152,8 @@ namespace king_me.Services
             return setoresDisponiveis;
         }
 
-        public bool IsSetorCheio(int setor, int idPartida)
+        public bool IsSetorCheio(int setor, int idPartida) //método na promoção
         {
-            // Implemente a lógica para verificar se o setor está cheio
-            // Esta é uma implementação de exemplo, ajuste conforme necessário
             string tabuleiro = KingMeServer.Jogo.VerificarVez(idPartida);
             if (string.IsNullOrEmpty(tabuleiro))
                 return false;
@@ -183,7 +169,7 @@ namespace king_me.Services
                 }
             }
 
-            return contadorPersonagens >= 3; // Assumindo que cada setor aceita até 3 personagens
+            return contadorPersonagens >= 4; 
         }
     }
 }

--- a/Services/VotoService.cs
+++ b/Services/VotoService.cs
@@ -1,49 +1,58 @@
 ﻿using KingMeServer;
 using king_me.Interfaces;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace king_me.Services
 {
 
-        public class VotoService : IVotoService
+    public class VotoService : IVotoService
+    {
+        private Dictionary<int, int> votosPorJogador = new Dictionary<int, int>();
+
+        public string Votar(int idJogador, string senhaJogador, string voto)
         {
-            private Dictionary<int, int> votosPorJogador = new Dictionary<int, int>();
+            voto = voto.ToUpper();
 
-            public string Votar(int idJogador, string senhaJogador, string voto)
+            if (voto.Length > 1)
+                return "ERRO:Voto com excesso de caracteres";
+
+            if (voto != "S" && voto != "N")
+                return "ERRO:Voto com caracter inválido (S/N)";
+
+            // Inicializa contador local se não existir
+            if (!votosPorJogador.ContainsKey(idJogador))
+                votosPorJogador[idJogador] = 3;
+
+            if (votosPorJogador[idJogador] <= 0)
+                voto = "S"; //caso não haja mais votos, o sim é obrigatório
+
+            string retorno = Jogo.Votar(idJogador, senhaJogador, voto);
+
+            if (!retorno.StartsWith("ERRO") && voto == "N")
             {
-                voto = voto.ToUpper();
-
-                if (voto.Length > 1)
-                    return "ERRO:Voto com excesso de caracteres";
-
-                if (voto != "S" && voto != "N")
-                    return "ERRO:Voto com caracter inválido (S/N)";
-
-                // Inicializa contador local se não existir
-                if (!votosPorJogador.ContainsKey(idJogador))
-                    votosPorJogador[idJogador] = 3;
-
-                if (votosPorJogador[idJogador] <= 0)
-                    return "ERRO:Você não tem mais votos disponíveis";
-
-                string retorno = Jogo.Votar(idJogador, senhaJogador, voto);
-
-                if (!retorno.StartsWith("ERRO"))
-                {
-                    votosPorJogador[idJogador]--; 
-                }
-
-                return retorno;
+                votosPorJogador[idJogador]--;
             }
 
+            return retorno;
+        }
 
         public int GetVotosRestantes(int jogador)
-            {
-                if (votosPorJogador.ContainsKey(jogador))
-                    return votosPorJogador[jogador];
+        {
+            if (votosPorJogador.ContainsKey(jogador))
+                return votosPorJogador[jogador];
 
-                return 3; 
+            return 3;
+        }
+
+        public void ResetarVotosJogadores(int idPartida)
+        {
+            var jogadores = votosPorJogador.Keys.ToList(); 
+            foreach (var jogador in jogadores)
+            {
+                votosPorJogador[jogador] = 3; 
             }
         }
     }
+}
 


### PR DESCRIPTION
### O que foi feito?

Foram feitos diversos commits corrigindo erros e adicionando uma condição de parada, para o fim da partida. As principais mudanças foram as seguintes

### FIXES
**label e txtTabuleiro**
O txtTabuleiro era usado antigamente quando não tínhamos o tabuleiro atual, com as cartas mostradas visualmente. No código haviam varias referências, que causavam erros/falhas, ao txtTabuleiro, as referências foram arrumadas e o txt removido junto de sua label

**Votação**
Até então o jogador tinha somente três votos totais, e eles decrementavam com qualquer voto. Segundo as regras do jogo, cada jogador tem três votos de veto, sem restrição para votos de aprovação. 

**Promoção**
O personagem no setor 0 não era promovido, e o máximo de cartas por setor estava setado como 3, no jogo são 4. Ambos os problemas foram arrumados

### FEAT
**Parada de partida**
Adicionado um if que verifica se a partida já foi encerrada, encerrando um timer e notificando o usuário através de uma messageBox