### PR TITLE
51 km 40 adicionar estratégia

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -57,7 +57,6 @@
             this.lblPersonagensFav = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
             this.btnIniciarPartida = new System.Windows.Forms.Button();
-            this.btnExibirCartas = new System.Windows.Forms.Button();
             this.lblPersonagensExistentes = new System.Windows.Forms.Label();
             this.txtPersonagensExistentes = new System.Windows.Forms.ListBox();
             this.btnVerificarVez = new System.Windows.Forms.Button();
@@ -378,17 +377,6 @@
             this.btnIniciarPartida.UseVisualStyleBackColor = true;
             this.btnIniciarPartida.Click += new System.EventHandler(this.btnIniciarPartida_Click);
             // 
-            // btnExibirCartas
-            // 
-            this.btnExibirCartas.Location = new System.Drawing.Point(379, 452);
-            this.btnExibirCartas.Margin = new System.Windows.Forms.Padding(4);
-            this.btnExibirCartas.Name = "btnExibirCartas";
-            this.btnExibirCartas.Size = new System.Drawing.Size(123, 28);
-            this.btnExibirCartas.TabIndex = 33;
-            this.btnExibirCartas.Text = "Exibir Cartas";
-            this.btnExibirCartas.UseVisualStyleBackColor = true;
-            this.btnExibirCartas.Click += new System.EventHandler(this.btnExibirCartas_Click);
-            // 
             // lblPersonagensExistentes
             // 
             this.lblPersonagensExistentes.AutoSize = true;
@@ -629,7 +617,6 @@
             this.Controls.Add(this.btnVerificarVez);
             this.Controls.Add(this.txtPersonagensExistentes);
             this.Controls.Add(this.lblPersonagensExistentes);
-            this.Controls.Add(this.btnExibirCartas);
             this.Controls.Add(this.btnIniciarPartida);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.lblPersonagensFav);
@@ -701,7 +688,6 @@
         private System.Windows.Forms.Label lblPersonagensFav;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button btnIniciarPartida;
-        private System.Windows.Forms.Button btnExibirCartas;
         private System.Windows.Forms.Label lblPersonagensExistentes;
         private System.Windows.Forms.ListBox txtPersonagensExistentes;
         private System.Windows.Forms.Button btnVerificarVez;

--- a/Form1.cs
+++ b/Form1.cs
@@ -126,14 +126,8 @@ namespace king_me
             tmrVerificarVez.Start();
 
             _partidaService.Iniciar(idJogador, senhaJogador);
-        }
 
-        private void btnExibirCartas_Click(object sender, EventArgs e)
-        {
             txtPersonagensFavoritos.Clear();
-
-            int idJogador = int.Parse(txtIdJogador.Text);
-            string senhaJogador = txtSenhaJogador.Text;
 
             string temp = _cartaService.ListarCartas(idJogador, senhaJogador);
             temp = temp.Substring(0, temp.Length - 2);
@@ -145,6 +139,7 @@ namespace king_me
                     txtPersonagensFavoritos.Text += mao.ExibirPersonagem(caractere) + "\r\n";
                 }
             }
+
         }
 
         private void CarregarPersonagens()

--- a/Form1.cs
+++ b/Form1.cs
@@ -469,6 +469,9 @@ namespace king_me
                 int idJogador = int.Parse(txtIdJogador.Text);
                 string senhaJogador = txtSenhaJogador.Text;
 
+                string cartasFavoritas = _cartaService.ListarCartas(idJogador, senhaJogador);
+                cartasFavoritas = cartasFavoritas.Substring(0, cartasFavoritas.Length - 2);
+
                 string tabuleiro = KingMeServer.Jogo.VerificarVez(int.Parse(txtIdPartida.Text));
                 string[] linhasTabuleiro = tabuleiro.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
                 tabuleiro = string.Join("\r\n", linhasTabuleiro.Skip(1));
@@ -477,23 +480,47 @@ namespace king_me
                     return;
 
                 string[] linhas = tabuleiro.Split(new string[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-                List<string> personagensPromoviveis = new List<string>();
+                linhas = linhas.Reverse().ToArray(); //deixa em ordem decrescente
 
-                foreach (string linha in linhas)
+                List<string> personagensPromoviveis = new List<string>();
+                List<string> personagensFavoritosPromoviveis = new List<string>();
+                List<string> personagensSetor5 = new List<string>();
+
+                foreach (string linha in linhas) 
                 {
                     string[] partes = linha.Split(',');
                     if (partes.Length >= 2 && int.TryParse(partes[0], out int setor))
                     {
                         if (setor >= 0 && setor <= 5 && !_tabuleiroService.IsSetorCheio(setor + 1, int.Parse(txtIdPartida.Text)))
                         {
-                            personagensPromoviveis.Add(partes[1]);
+                            if (setor == 5)
+                            {
+                                personagensSetor5.Add(partes[1]);
+                            }
+                            else
+                            {
+                                personagensPromoviveis.Add(partes[1]);
+                                if (cartasFavoritas.Contains(partes[1]))
+                                {
+                                    personagensFavoritosPromoviveis.Add(partes[1]);
+                                }
+                            }
                         }
                     }
+                }
+                int a = 0; ; // debbugging
+                if (personagensPromoviveis.Count == 0 && personagensSetor5.Count > 0)
+                {
+                    personagensPromoviveis.AddRange(personagensSetor5);
                 }
 
                 if (personagensPromoviveis.Count > 0)
                 {
-                    string personagemParaPromover = personagensPromoviveis[0];
+                    string personagemParaPromover;
+                    if (personagensFavoritosPromoviveis.Count > 0)
+                        personagemParaPromover = personagensFavoritosPromoviveis[0];
+                    else
+                        personagemParaPromover = personagensPromoviveis[0];
 
                     string retorno = _cartaService.Promover(idJogador, senhaJogador, personagemParaPromover);
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -508,7 +508,7 @@ namespace king_me
                         }
                     }
                 }
-                int a = 0; ; // debbugging
+                //int a = 0; //Colocar breakpoint nessa linha e descomentar caso queira visualizar as listas
                 if (personagensPromoviveis.Count == 0 && personagensSetor5.Count > 0)
                 {
                     personagensPromoviveis.AddRange(personagensSetor5);


### PR DESCRIPTION
### O que foi feito?
Incrementada a estratégia de posicionamento e promoção.

**Posicionamento**
O jogador vai tentar posicionar primeiro os seus personagens favoritos no setor mais alto que estiver disponível, caso estejam todos posicionados ele posiciona personagens aleatórios

**Promoção**
O jogador vai sempre tentar promover seus personagens favoritos, caso não seja possível ele promove um personagem qualquer. Primeiro o tabuleiro é percorrido, por padrão ele vem na ordem crescente na relação de setor/jogador, para que a estratégia seja efetiva a lista é invertida. 
![image](https://github.com/user-attachments/assets/0222a426-49a7-45dd-9ac9-fb786a8f156f)

Após isso tem três listas

1. Uma lista de personagens promovíveis
2. Uma lista de personagens favoritos promovíveis
3. Uma lista de personagens no setor 5 (útil para que uma carta não seja promovida para o setor 10 prematuramente)

O código vai percorrer cada linha do tabuleiro e ver se o personagem é promovível, e caso o personagem esteja no setor 5, ele vai direto para a terceira lista. 
Caso não, ele entra no else e vai adicionar na primeira lista, dentro desse else, se o personagem for um dos favoritos ele também vai ser adicionado na segunda lista.
Caso não tenha mais nenhum personagem promovível que não seja do quinto setor, ele vai adicionar todos do quinto setor na primeira lista, para que assim sejam promovidos ao setor 10 e as votações sejam iniciadas, com a possibilidade do fim da rodada.
![image](https://github.com/user-attachments/assets/291bee9c-e1a5-4c97-a5f7-3f42848609fc)

Depois só há uma verificação para ver se há um personagem favorito a ser promovido, caso essa lista esteja vazia ele vai promover um personagem qualquer.
![image](https://github.com/user-attachments/assets/81982cf5-b0ae-45fa-9c83-79850ead2bdd)

